### PR TITLE
Correcting "docker run" runtime error (libpython2.7.so not found)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,13 @@ RUN apk --update add \
     openssl \
     py-cryptography \
     py-virtualenv \
+    python-dev \
     ca-certificates
 RUN apk --update add --virtual build-deps \
     build-base \
     git \
     libev-dev \
     openssl-dev \
-    python-dev \
     wget \
  && virtualenv /app/ve \
  && /app/ve/bin/pip install -U pip \


### PR DESCRIPTION
apk block above it. python-dev provides libpython2.7.so ; this
eliminates a runtime error on initialization ("docker run").